### PR TITLE
Add params cssPattern and jsPattern to modify the initial pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ var wiredep = require('wiredep')({
   directory: 'the directory of your Bower packages.',
   bowerJson: 'your bower.json file contents.',
   ignorePath: 'optional path to ignore from the injected filepath.',
-  htmlFile: 'the path to the HTML file to take control of.'
+  htmlFile: 'the path to the HTML file to take control of.',
+  jsPattern: 'use <filePath> where you want include your file path. Default: <script src="<filePath>"></script>',
+  cssPattern: 'use <filePath> where you want include your file path. Default: <link rel="stylesheet" href="<filePath>" />'
 });
 ```
 

--- a/bin/wiredep
+++ b/bin/wiredep
@@ -18,7 +18,6 @@ var helpers = require('../lib/helpers');
  */
 module.exports = function (opts) {
   var config = helpers.createStore();
-
   config.set
     ('warnings', [])
     ('global-dependencies', helpers.createStore())
@@ -26,6 +25,8 @@ module.exports = function (opts) {
     ('directory', opts.directory)
     ('ignore-path', opts.ignorePath)
     ('html-file', opts.htmlFile)
+    ('css-pattern', opts.cssPattern)
+    ('js-pattern', opts.jsPattern)
     ('html', String(fs.readFileSync(opts.htmlFile)));
 
   require('../lib/detect-dependencies')(config);

--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -12,6 +12,8 @@ var fs = require('fs');
 
 var globalDependenciesSorted;
 var ignorePath;
+var jsPattern;
+var cssPattern;
 
 var regex = {
   bower: /(([\s\t]*)<!--\s*bower:*(\S*)\s*-->)(\n|\r|.)*?(<!--\s*endbower\s*-->)/gi,
@@ -54,9 +56,21 @@ var findStyleSheets = function (match, stylesheet) {
 var replace = function (blockType, spacing, path) {
   var replacePattern = {
     css: function (path) {
+      if (cssPattern) {
+        var pattern = cssPattern;
+
+        return pattern.replace('\<filePath\>', path);
+      }
+
       return '<link rel="stylesheet" href="' + path + '" />';
     },
     js: function (path) {
+      if (jsPattern) {
+        var pattern = jsPattern;
+
+        return pattern.replace('\<filePath\>', path);
+      }
+
       return '<script src="' + path + '"></script>';
     }
   }[blockType];
@@ -117,6 +131,9 @@ var injectScripts = function (match, startBlock, spacing, blockType, oldScripts,
  * @return {object} config
  */
 module.exports = function inject(config) {
+  jsPattern = config.get('js-pattern');
+  cssPattern = config.get('css-pattern');
+
   globalDependenciesSorted = config.get('global-dependencies-sorted');
   ignorePath = config.get('ignore-path');
 


### PR DESCRIPTION
Hi,
This is really usefull for a Symfony2 project. We can add the 'asset' filter on the pattern.

Exemple : 
var wiredep = require('wiredep')({
  [...],
  cssPattern: '<link rel="stylesheet" href="{{ asset(\'<filePath>\') }}" />',
  jsPattern: '<script src="{{ asset(\'<filePath>\') }}"></script>'
});
