### PR TITLE
Don't assign wiredep() result

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wire dependencies to your source code.
 Install the module with: `npm install wiredep --save`
 
 ```js
-var wiredep = require('wiredep')({
+require('wiredep')({
   directory: 'the directory of your Bower packages.',
   bowerJson: 'your bower.json file contents.',
   ignorePath: 'optional path to ignore from the injected filepath.',


### PR DESCRIPTION
Since executing `wiredep()` doesn't return anything, we don't really need to store the result.

Obviously, the PR would be incomplete without a GIF:

![BOOP!](https://f.cloud.github.com/assets/9906/1699448/dd873d5c-5f9e-11e3-8b79-dffd2ac3b6d7.gif)
