### PR TITLE
Fix override issue of default Block values

### DIFF
--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -129,7 +129,7 @@ module.exports = function inject(config) {
   _(config.get('file-types')).each(function (fileTypeConfig, fileType) {
     fileTypes[fileType] = fileTypes[fileType] || {};
     _.each(fileTypeConfig, function (config, configKey) {
-      if (_.isObject(fileTypes[fileType][configKey])) {
+      if (_.isPlainObject(fileTypes[fileType][configKey])) {
         fileTypes[fileType][configKey] =
           _.assign(fileTypes[fileType][configKey], config);
       } else {


### PR DESCRIPTION
The default block values for HTML and YAML are both RegExp objects. These were getting caught by the _.isObject call, and thus were sent through _.assign. However, _.assign does not override RegExp objects. Therefore, it was not possible to override the default values.

Changing this to _.isPlainObject will cause RegExp objects to fall down to the else case, which will just assign the new value directly, fixing the issue.
