### PR TITLE
Update detect-dependencies.js

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -23,7 +23,7 @@ var prop = helpers.prop;
  * @return {object} the component's config file
  */
 var findComponentConfigFile = function (config, component) {
-  var componentConfigFile;
+  var componentConfigFile = {};
 
   ['.bower.json',
     'bower.json',


### PR DESCRIPTION
An empty initialized componentConfigFile can cause "Cannot read property 'main' of undefined.", if there is no such file for the component.

Fixes issue #36 for grunt-bower-install.
