### PR TITLE
Remove warning for excluded components.

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -109,9 +109,9 @@ var gatherInfo = function (config) {
 
     var testExclude = _.find(config.get('exclude'), function (pattern) {
       return path.join(config.get('bower-directory'), component).match(pattern);
-    })
+    });
 
-    if (dep.main.length === 0 && testExclude == undefined) {
+    if (dep.main.length === 0 && testExclude === undefined) {
 
       // can't find the main file. this config file is useless!
       warnings.push(component + ' was not injected in your file.');


### PR DESCRIPTION
Its extremely noisy to see these repeatedly with a large bower file full of unsupported components. If the user manually excludes them, the warnings should not be displayed.
