### PR TITLE
Allow for overrides to be defined in bower.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ require('wiredep')({
 });
 ```
 
+## Bower Overrides
+While not standard, a number of other plugins allow you to override properties in a plugin's `bower.json` via an `overrides` property in your projects `bower.json`. This allows you to use `wiredep` with other plugins, such as `gulp-bower-files` that use this same pattern.
+
+As an example, this is what your `bower.json` may look like if you wanted to override `package-without-main`'s `main` file:
+
+```js
+{
+  ...
+  dependencies: {
+    "package-without-main": "1.0.0"
+  },
+  overrides: {
+    "package-without-main": {
+      "main": "dist/package-without-main.js"
+    }
+  }
+}
+```
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -52,6 +52,11 @@ var findMainFiles = function (config, component, componentConfigFile) {
   var filePaths = [];
   var file;
 
+  var bowerJson = config.get('bower.json');
+  if (bowerJson.overrides && bowerJson.overrides[component]) {
+    componentConfigFile = _.merge(componentConfigFile, bowerJson.overrides[component]);
+  }
+
   if (_.isString(componentConfigFile.main)) {
     // start by looking for what every component should have: config.main
     filePaths = [componentConfigFile.main];

--- a/test/fixture/bower_components/fake-package-with-override/bower.json
+++ b/test/fixture/bower_components/fake-package-with-override/bower.json
@@ -1,0 +1,4 @@
+{
+  "name": "fake-package-without-main",
+  "version": "1.0.0"
+}

--- a/test/fixture/bower_components/fake-package-with-override/dist/fake-package-with-override.js
+++ b/test/fixture/bower_components/fake-package-with-override/dist/fake-package-with-override.js
@@ -1,0 +1,3 @@
+(function () {
+  // this should be injected!
+})();

--- a/test/fixture/bower_packages_without_main.json
+++ b/test/fixture/bower_packages_without_main.json
@@ -3,6 +3,12 @@
   "version": "0.0.0",
   "dependencies": {
     "fake-package-without-main": "1.0.0",
-    "fake-package-without-main-and-confusing-file-tree": "1.0.0"
+    "fake-package-without-main-and-confusing-file-tree": "1.0.0",
+    "fake-package-with-override": "1.0.0"
+  },
+  "overrides": {
+    "fake-package-with-override": {
+        "main": "dist/fake-package-with-override.js"
+    }
   }
 }

--- a/test/fixture/html/index-packages-without-main-expected.html
+++ b/test/fixture/html/index-packages-without-main-expected.html
@@ -8,6 +8,7 @@
 
   <!-- bower:js -->
   <script src="bower_components/fake-package-without-main/fake-package-without-main.js"></script>
+  <script src="bower_components/fake-package-with-override/dist/fake-package-with-override.js"></script>
   <!-- endbower -->
 </body>
 </html>


### PR DESCRIPTION
I know you said you didn't want to add it, but just in case. =)

All this does is merge the overrides you define on top of the `Bower JSON` it loads from the plugins' bower.json.

Related to #25.
