### PR TITLE
include .bower.json in findComponentConfigFile()

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -25,7 +25,7 @@ var prop = helpers.prop;
 var findComponentConfigFile = function (config, component) {
   var componentConfigFile;
 
-  ['bower.json', 'component.json', 'package.json'].
+  ['bower.json', '.bower.json', 'component.json', 'package.json'].
     forEach(function (configFile) {
       configFile = path.join(config.get('bower-directory'), component, configFile);
   


### PR DESCRIPTION
This might be a little bit controversial. I excluded my `bower.json` in my Bower packages, because `.bower.json` will be generated anyway.

I would wait what the Bower team recommends in this case. See discussion here: https://github.com/bower/bower/issues/1174

If they recommend that I should change my Bower packages, you can close this pull request.
