### PR TITLE
support function replace for js.

### DIFF
--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -64,7 +64,11 @@ var replaceIncludes = function (file, fileType, returnType) {
         return filesCaught.indexOf(filePath) === -1;
       }).
       forEach(function (filePath) {
-        newFileContents += spacing + fileType.replace[blockType].replace('{{filePath}}', filePath);
+        if (typeof fileType.replace[blockType] === 'function') {
+          newFileContents += spacing + fileType.replace[blockType](filePath);
+        } else if (typeof fileType.replace[blockType] === 'string') {
+          newFileContents += spacing + fileType.replace[blockType].replace('{{filePath}}', filePath);
+        }        
       });
 
     return newFileContents + spacing + endBlock;


### PR DESCRIPTION
Example

``` js
        fileTypes: {
          html: {
            replace: {
              js: function(filepath) {
                return '<script class=' + classname + ' src=' + filePath + '></script>'
              }
            }
          }
        }
```
