### PR TITLE
Create test for dependencies override and move override logic.

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -47,19 +47,8 @@ var findComponentConfigFile = function (config, component) {
  * @return {array} the array of paths to the component's primary file(s)
  */
 var findMainFiles = function (config, component, componentConfigFile) {
-  var overrides = config.get('overrides');
   var filePaths = [];
   var file;
-
-  if (overrides && overrides[component]) {
-    if (overrides[component].dependencies) {
-      componentConfigFile.dependencies = overrides[component].dependencies;
-    }
-
-    if (overrides[component].main) {
-      componentConfigFile.main = overrides[component].main;
-    }
-  }
 
   if (_.isString(componentConfigFile.main)) {
     // start by looking for what every component should have: config.main
@@ -106,6 +95,18 @@ var gatherInfo = function (config) {
 
     var componentConfigFile = findComponentConfigFile(config, component);
     var warnings = config.get('warnings');
+
+    var overrides = config.get('overrides');
+
+    if (overrides && overrides[component]) {
+      if (overrides[component].dependencies) {
+        componentConfigFile.dependencies = overrides[component].dependencies;
+      }
+
+      if (overrides[component].main) {
+        componentConfigFile.main = overrides[component].main;
+      }
+    }
 
     var mains = findMainFiles(config, component, componentConfigFile);
     var fileTypes = _.chain(mains).map(path.extname).unique().value();

--- a/test/fixture/bower_components/fake-package-without-dependencies/bower.json
+++ b/test/fixture/bower_components/fake-package-without-dependencies/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-package-without-dependencies",
+  "version": "1.0.0",
+  "main": "fake-package-without-dependencies.js"
+}

--- a/test/fixture/bower_components/fake-package-without-dependencies/fake-package-without-dependencies.js
+++ b/test/fixture/bower_components/fake-package-without-dependencies/fake-package-without-dependencies.js
@@ -1,0 +1,3 @@
+(function () {
+  // this should still be injected!
+})();

--- a/test/fixture/bower_packages_without_dependencies.json
+++ b/test/fixture/bower_packages_without_dependencies.json
@@ -1,0 +1,14 @@
+{
+  "name": "wiredep-test",
+  "version": "0.0.0",
+  "dependencies": {
+    "fake-package-without-dependencies": "1.0.0"
+  },
+  "overrides": {
+    "fake-package-without-dependencies": {
+      "dependencies": {
+        "codecode": "0.0.3"        
+      }
+    }
+  }
+}

--- a/test/fixture/html/index-override-dependencies-actual.html
+++ b/test/fixture/html/index-override-dependencies-actual.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <script src="../bower_components/modernizr/modernizr.js"></script>
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
+</head>
+<body>
+
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-override-dependencies-expected.html
+++ b/test/fixture/html/index-override-dependencies-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <script src="../bower_components/modernizr/modernizr.js"></script>
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
+</head>
+<body>
+
+  <!-- bower:js -->
+  <script src="../bower_components/jquery/jquery.js"></script>
+  <script src="../bower_components/codecode/dist/codecode.js"></script>
+  <script src="../bower_components/fake-package-without-dependencies/fake-package-without-dependencies.js"></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -269,6 +269,25 @@ exports.wiredep = {
     test.done();
   },
 
+  replaceHtmlWithUsingConfigOverridesForDependencies: function (test) {
+    var filePaths = getFilePaths('index-override-dependencies', 'html');
+
+    var bowerJson = require('../.tmp/bower_packages_without_dependencies.json');
+    var overrides = bowerJson.overrides;
+    delete bowerJson.overrides;
+
+    wiredep({
+      directory: '.tmp/bower_components',
+      bowerJson: bowerJson,
+      overrides: overrides,
+      src: [filePaths.actual],
+      ignorePath: '.tmp/'
+    });
+
+    test.equal(filePaths.read('expected'), filePaths.read('actual'));
+    test.done();
+  },
+
   replaceDeepNestedFileWithRelativePath: testReplace('html/deep/nested'),
 
   replaceHtmlWithCustomReplaceFunction: function (test) {


### PR DESCRIPTION
Create test for `dependencies` override and move override logic (for both `dependencies` and `main`) in a more... logical place.

The code was kinda hard to follow to see what was happening with the `dependencies` override, so I moved it at @stephenplusplus' suggestion.

We also didn't have a test testing all this `dependencies` voodoo, so I made one for that.
