### PR TITLE
Check if opts.exclude is an array and if not wrap the value in one.

### DIFF
--- a/wiredep.js
+++ b/wiredep.js
@@ -147,7 +147,7 @@ var wiredep = function (opts) {
     ('dependencies', opts.dependencies === false ? false : true)
     ('detectable-file-types', [])
     ('dev-dependencies', opts.devDependencies)
-    ('exclude', _.isArray(opts.exclude) ? opts.exclude : [ opts.exclude ])
+    ('exclude', Array.isArray(opts.exclude) ? opts.exclude : [ opts.exclude ])
     ('file-types', mergeFileTypesWithDefaults(opts.fileTypes))
     ('global-dependencies', helpers.createStore())
     ('ignore-path', opts.ignorePath)


### PR DESCRIPTION
This was noticed when using the CLI and passing only one dependency to exclude. Minimist sees this as only a string and does not provide any method for casting to an array so the value that is passed to wiredep for the exclude parameter ends up to be a string and this messes up the filterExcludedDependencies method.
