### PR TITLE
code style cleanup.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,6 @@
   "curly": true,
   "eqeqeq": true,
   "immed": true,
-  "latedef": true,
   "newcap": true,
   "noarg": true,
   "sub": true,

--- a/lib/default-file-types.js
+++ b/lib/default-file-types.js
@@ -1,0 +1,82 @@
+module.exports = {
+  html: {
+    block: /(([ \t]*)<!--\s*bower:*(\S*)\s*-->)(\n|\r|.)*?(<!--\s*endbower\s*-->)/gi,
+    detect: {
+      js: /<script.*src=['"]([^'"]+)/gi,
+      css: /<link.*href=['"]([^'"]+)/gi
+    },
+    replace: {
+      js: '<script src="{{filePath}}"></script>',
+      css: '<link rel="stylesheet" href="{{filePath}}" />'
+    }
+  },
+
+  jade: {
+    block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+    detect: {
+      js: /script\(.*src=['"]([^'"]+)/gi,
+      css: /link\(.*href=['"]([^'"]+)/gi
+    },
+    replace: {
+      js: 'script(src=\'{{filePath}}\')',
+      css: 'link(rel=\'stylesheet\', href=\'{{filePath}}\')'
+    }
+  },
+
+  less: {
+    block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+    detect: {
+      css: /@import\s['"](.+css)['"]/gi,
+      less: /@import\s['"](.+less)['"]/gi
+    },
+    replace: {
+      css: '@import "{{filePath}}";',
+      less: '@import "{{filePath}}";'
+    }
+  },
+
+  sass: {
+    block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+    detect: {
+      css: /@import\s(.+css)/gi,
+      sass: /@import\s(.+sass)/gi,
+      scss: /@import\s(.+scss)/gi
+    },
+    replace: {
+      css: '@import {{filePath}}',
+      sass: '@import {{filePath}}',
+      scss: '@import {{filePath}}'
+    }
+  },
+
+  scss: {
+    block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+    detect: {
+      css: /@import\s['"](.+css)['"]/gi,
+      sass: /@import\s['"](.+sass)['"]/gi,
+      scss: /@import\s['"](.+scss)['"]/gi
+    },
+    replace: {
+      css: '@import "{{filePath}}";',
+      sass: '@import "{{filePath}}";',
+      scss: '@import "{{filePath}}";'
+    }
+  },
+
+  yaml: {
+    block: /(([ \t]*)#\s*bower:*(\S*))(\n|\r|.)*?(#\s*endbower)/gi,
+    detect: {
+      js: /-\s(.+js)/gi,
+      css: /-\s(.+css)/gi
+    },
+    replace: {
+      js: '- {{filePath}}',
+      css: '- {{filePath}}'
+    }
+  }
+};
+
+
+module.exports['default'] = module.exports.html;
+module.exports.htm = module.exports.html;
+module.exports.yml = module.exports.yaml;

--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -1,18 +1,41 @@
-/*
- * detect-dependencies.js
- * https://github.com/stephenplusplus/wiredep
- *
- * Copyright (c) 2013 Stephen Sawchuk
- * Licensed under the MIT license.
- */
-
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var _ = require('lodash');
-var helpers = require('./helpers');
-var prop = helpers.prop;
+var $ = require('modmod')('fs', 'lodash', 'path', 'propprop');
+var _ = $.lodash;
+
+
+/**
+ * Detect dependencies of the components from `bower.json`.
+ *
+ * @param  {object} config the global configuration object.
+ * @return {object} config
+ */
+function detectDependencies(config) {
+  var allDependencies = {};
+
+  if (config.get('dependencies')) {
+    _.assign(allDependencies, config.get('bower.json').dependencies);
+  }
+
+  if (config.get('dev-dependencies')) {
+    _.assign(allDependencies, config.get('bower.json').devDependencies);
+  }
+
+  _.each(allDependencies, gatherInfo(config));
+
+  config.set('global-dependencies-sorted', filterExcludedDependencies(
+    config.get('detectable-file-types').
+      reduce(function (acc, fileType) {
+        if (!acc[fileType]) {
+          acc[fileType] = prioritizeDependencies(config, '.' + fileType);
+        }
+        return acc;
+      }, {}),
+    config.get('exclude')
+  ));
+
+  return config;
+}
 
 
 /**
@@ -22,31 +45,31 @@ var prop = helpers.prop;
  * @param  {string} component  the name of the component to dig for
  * @return {object} the component's config file
  */
-var findComponentConfigFile = function (config, component) {
+function findComponentConfigFile(config, component) {
   var componentConfigFile;
 
   ['bower.json', '.bower.json', 'component.json', 'package.json'].
     forEach(function (configFile) {
-      configFile = path.join(config.get('bower-directory'), component, configFile);
+      configFile = $.path.join(config.get('bower-directory'), component, configFile);
 
-      if (!_.isObject(componentConfigFile) && fs.existsSync(configFile)) {
-        componentConfigFile = JSON.parse(fs.readFileSync(configFile));
+      if (!_.isObject(componentConfigFile) && $.fs.existsSync(configFile)) {
+        componentConfigFile = JSON.parse($.fs.readFileSync(configFile));
       }
     });
 
   return componentConfigFile;
-};
+}
 
 
 /**
- * Find the main file the component refers to. It's not always main :(
+ * Find the main file the component refers to. It's not always `main` :(
  *
  * @param  {object} config        the global configuration object
  * @param  {string} component     the name of the component to dig for
  * @param  {componentConfigFile}  the component's config file
  * @return {array} the array of paths to the component's primary file(s)
  */
-var findMainFiles = function (config, component, componentConfigFile) {
+function findMainFiles(config, component, componentConfigFile) {
   var filePaths = [];
   var file;
 
@@ -59,16 +82,16 @@ var findMainFiles = function (config, component, componentConfigFile) {
     // still haven't found it. is it stored in config.scripts, then?
     filePaths = componentConfigFile.scripts;
   } else {
-    file = path.join(config.get('bower-directory'), component, componentConfigFile.name + '.js');
-    if (fs.existsSync(file)) {
+    file = $.path.join(config.get('bower-directory'), component, componentConfigFile.name + '.js');
+    if ($.fs.existsSync(file)) {
       filePaths = [componentConfigFile.name + '.js'];
     }
   }
 
   return filePaths.map(function (file) {
-    return path.join(config.get('bower-directory'), component, file);
+    return $.path.join(config.get('bower-directory'), component, file);
   });
-};
+}
 
 
 /**
@@ -77,7 +100,7 @@ var findMainFiles = function (config, component, componentConfigFile) {
  * @param  {object} config   the global configuration object
  * @return {function} the iterator function, called on every component
  */
-var gatherInfo = function (config) {
+function gatherInfo(config) {
   /**
    * The iterator function, which is called on each component.
    *
@@ -109,14 +132,14 @@ var gatherInfo = function (config) {
     }
 
     var mains = findMainFiles(config, component, componentConfigFile);
-    var fileTypes = _.chain(mains).map(path.extname).unique().value();
+    var fileTypes = _.chain(mains).map($.path.extname).unique().value();
 
     dep.main = mains;
     dep.type = fileTypes;
     dep.name = componentConfigFile.name;
 
     var depIsExcluded = _.find(config.get('exclude'), function (pattern) {
-      return path.join(config.get('bower-directory'), component).match(pattern);
+      return $.path.join(config.get('bower-directory'), component).match(pattern);
     });
 
     if (dep.main.length === 0 && !depIsExcluded) {
@@ -124,7 +147,7 @@ var gatherInfo = function (config) {
       warnings.push(component + ' was not injected in your file.');
       warnings.push(
         'Please go take a look in "'
-        + path.join(config.get('bower-directory'), component)
+        + $.path.join(config.get('bower-directory'), component)
         + '" for the file you need, then manually include it in your file.');
 
       config.set('warnings', warnings);
@@ -139,7 +162,7 @@ var gatherInfo = function (config) {
 
     config.get('global-dependencies').set(component, dep);
   };
-};
+}
 
 
 /**
@@ -149,7 +172,7 @@ var gatherInfo = function (config) {
  * @param  {object} b  dependency b
  * @return {number} the priority of dependency a in comparison to dependency b
  */
-var dependencyComparator = function (a, b) {
+function dependencyComparator(a, b) {
   var aNeedsB = false;
   var bNeedsA = false;
 
@@ -174,7 +197,7 @@ var dependencyComparator = function (a, b) {
   }
 
   return 0;
-};
+}
 
 
 /**
@@ -185,7 +208,7 @@ var dependencyComparator = function (a, b) {
  * @param  {array} right
  * @return {array} the sorted, merged array
  */
-var merge = function (left, right) {
+function merge(left, right) {
   var result = [];
   var leftIndex = 0;
   var rightIndex = 0;
@@ -201,7 +224,7 @@ var merge = function (left, right) {
   return result.
     concat(left.slice(leftIndex)).
     concat(right.slice(rightIndex));
-};
+}
 
 
 /**
@@ -210,7 +233,7 @@ var merge = function (left, right) {
  * @param  {array} items
  * @return {array} the sorted array
  */
-var mergeSort = function (items) {
+function mergeSort(items) {
   if (items.length < 2) {
     return items;
   }
@@ -221,7 +244,7 @@ var mergeSort = function (items) {
     mergeSort(items.slice(0, middle)),
     mergeSort(items.slice(middle))
   );
-};
+}
 
 
 /**
@@ -242,7 +265,7 @@ var eliteDependencies = [
  * @param  {string} fileType  the type of file to prioritize
  * @return {array} the sorted items of 'path/to/main/files.ext' sorted by type
  */
-var prioritizeDependencies = function (config, fileType) {
+ function prioritizeDependencies(config, fileType) {
   var eliteDependenciesCaught = [];
 
   var dependencies = mergeSort(
@@ -257,7 +280,7 @@ var prioritizeDependencies = function (config, fileType) {
           return true;
         }
       })
-    ).map(prop('main'));
+    ).map($.propprop('main'));
 
   eliteDependenciesCaught.
     forEach(function (dependency) {
@@ -269,9 +292,9 @@ var prioritizeDependencies = function (config, fileType) {
       flatten().
       value().
       filter(function (main) {
-        return path.extname(main) === fileType;
+        return $.path.extname(main) === fileType;
       });
-};
+}
 
 
 /**
@@ -281,7 +304,7 @@ var prioritizeDependencies = function (config, fileType) {
  * @param  {array} patterns         array of patterns to match against
  * @return {array} items that don't match any of the patterns
  */
-var filterExcludedDependencies = function (allDependencies, patterns) {
+function filterExcludedDependencies(allDependencies, patterns) {
   return _.transform(allDependencies, function (result, dependencies, fileType) {
     result[fileType] = _.reject(dependencies, function (dependency) {
       return _.find(patterns, function (pattern) {
@@ -289,38 +312,7 @@ var filterExcludedDependencies = function (allDependencies, patterns) {
       });
     });
   });
-};
+}
 
 
-/**
- * Detect dependencies of the components from `bower.json`.
- *
- * @param  {object} config the global configuration object.
- * @return {object} config
- */
-module.exports = function detect(config) {
-  var allDependencies = {};
-
-  if (config.get('dependencies')) {
-    _.assign(allDependencies, config.get('bower.json').dependencies);
-  }
-
-  if (config.get('dev-dependencies')) {
-    _.assign(allDependencies, config.get('bower.json').devDependencies);
-  }
-
-  _.each(allDependencies, gatherInfo(config));
-
-  config.set('global-dependencies-sorted', filterExcludedDependencies(
-    config.get('detectable-file-types').
-      reduce(function (acc, fileType) {
-        if (!acc[fileType]) {
-          acc[fileType] = prioritizeDependencies(config, '.' + fileType);
-        }
-        return acc;
-      }, {}),
-    config.get('exclude')
-  ));
-
-  return config;
-};
+module.exports = detectDependencies;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,11 +1,3 @@
-/*
- * helpers.js
- * https://github.com/stephenplusplus/wiredep
- *
- * Copyright (c) 2013 Stephen Sawchuk
- * Licensed under the MIT license.
- */
-
 'use strict';
 
 var chalk = require('chalk');
@@ -48,19 +40,6 @@ module.exports.createStore = function () {
   return {
     set: set,
     get: get
-  };
-};
-
-
-/**
- * Return just a property from an object.
- *
- * @param  {string} prop  the key of the object to return
- * @return {function}
- */
-module.exports.prop = function (prop) {
-  return function (item) {
-    return item[prop];
   };
 };
 

--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -1,29 +1,41 @@
-/*
- * inject-dependencies.js
- * https://github.com/stephenplusplus/wiredep
- *
- * Copyright (c) 2013 Stephen Sawchuk
- * Licensed under the MIT license.
- */
-
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var chalk = require('chalk');
+var $ = require('modmod')('chalk', 'fs', 'path');
 
+var fileTypes;
+var filesCaught = [];
 var globalDependenciesSorted;
 var ignorePath;
-var fileTypes;
 
 
 /**
- * Find references already on the page, not in a Bower block.
+ * Inject dependencies into the specified source file.
+ *
+ * @param  {object} config  the global configuration object.
+ * @return {object} config
  */
-var filesCaught = [];
+function injectDependencies(config) {
+  var stream = config.get('stream');
+
+  filesCaught = [];
+  globalDependenciesSorted = config.get('global-dependencies-sorted');
+  ignorePath = config.get('ignore-path');
+  fileTypes = config.get('file-types');
+
+  if (stream.src) {
+    config.set('stream', {
+      src: injectScriptsStream(stream.path, stream.src, stream.fileType),
+      fileType: stream.fileType
+    });
+  } else {
+    config.get('src').forEach(injectScripts);
+  }
+
+  return config;
+}
 
 
-var replaceIncludes = function (file, fileType, returnType) {
+function replaceIncludes(file, fileType, returnType) {
   /**
    * Callback function after matching our regex from the source file.
    *
@@ -53,9 +65,9 @@ var replaceIncludes = function (file, fileType, returnType) {
 
     dependencies.
       map(function (filePath) {
-        return path.join(
-          path.relative(path.dirname(file), path.dirname(filePath)),
-          path.basename(filePath)
+        return $.path.join(
+          $.path.relative($.path.dirname(file), $.path.dirname(filePath)),
+          $.path.basename(filePath)
         ).replace(/\\/g, '/').replace(ignorePath, '');
       }).
       filter(function (filePath) {
@@ -71,7 +83,7 @@ var replaceIncludes = function (file, fileType, returnType) {
 
     return newFileContents + spacing + endBlock;
   };
-};
+}
 
 
 /**
@@ -80,9 +92,9 @@ var replaceIncludes = function (file, fileType, returnType) {
  *
  * @param  {string} filePath  path to the source file
  */
-var injectScripts = function (filePath) {
-  var contents = String(fs.readFileSync(filePath));
-  var fileExt = path.extname(filePath).substr(1);
+function injectScripts(filePath) {
+  var contents = String($.fs.readFileSync(filePath));
+  var fileExt = $.path.extname(filePath).substr(1);
   var fileType = fileTypes[fileExt] || fileTypes['default'];
   var returnType = /\r\n/.test(contents) ? '\r\n' : '\n';
 
@@ -92,16 +104,16 @@ var injectScripts = function (filePath) {
   );
 
   if (contents !== newContents) {
-    fs.writeFileSync(filePath, newContents);
+    $.fs.writeFileSync(filePath, newContents);
 
     if (process.env.NODE_ENV !== 'test') {
-      console.log(chalk.cyan(filePath) + ' modified.');
+      console.log($.chalk.cyan(filePath) + ' modified.');
     }
   }
-};
+}
 
 
-var injectScriptsStream = function (filePath, contents, fileExt) {
+function injectScriptsStream(filePath, contents, fileExt) {
   var returnType = /\r\n/.test(contents) ? '\r\n' : '\n';
   var fileType = fileTypes[fileExt] || fileTypes['default'];
 
@@ -109,31 +121,7 @@ var injectScriptsStream = function (filePath, contents, fileExt) {
     fileType.block,
     replaceIncludes(filePath, fileType, returnType)
   );
-};
+}
 
 
-/**
- * Injects dependencies into the specified HTML file.
- *
- * @param  {object} config  the global configuration object.
- * @return {object} config
- */
-module.exports = function inject(config) {
-  var stream = config.get('stream');
-
-  filesCaught = [];
-  globalDependenciesSorted = config.get('global-dependencies-sorted');
-  ignorePath = config.get('ignore-path');
-  fileTypes = config.get('file-types');
-
-  if (stream.src) {
-    config.set('stream', {
-      src: injectScriptsStream(stream.path, stream.src, stream.fileType),
-      fileType: stream.fileType
-    });
-  } else {
-    config.get('src').forEach(injectScripts);
-  }
-
-  return config;
-};
+module.exports = injectDependencies;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "glob": "~3.2.8",
     "lodash": "~1.3.0",
     "minimist": "^0.1.0",
+    "modmod": "^0.1.1",
+    "propprop": "^0.3.0",
     "through2": "~0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@CWSpear please check this out whenever you have time. I did a little shifting around of code. The main changes:
1. Change `var yo = function () {};` to `function yo() {}`.
2. Use [`modmod`](https://github.com/stephenplusplus/modmod) to change multiple line var decls/requires into a one liner. External dependencies now look like `var $ = require('modmod')('fs', 'path');`, then are namespaced under `$`: `$.fs.readFile();`
3. Moved the default file type object to its own file, `default-file-types.js`.

All the tests pass, and things look happy. Just wanted a second set of :eyes: for a sanity check.
