### PR TITLE
Add root slash support via options

### DIFF
--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -81,7 +81,7 @@ function replaceIncludes(file, fileType, returnType) {
         return filesCaught.indexOf(filePath) === -1;
       }).
       forEach(function (filePath) {
-        filepath = addRootSlash ? prependSlash(filePath) : filePath;
+        filePath = addRootSlash ? prependSlash(filePath) : filePath;
         if (typeof fileType.replace[blockType] === 'function') {
           newFileContents += spacing + fileType.replace[blockType](filePath);
         } else if (typeof fileType.replace[blockType] === 'string') {


### PR DESCRIPTION
Hi,

I have added the possibility of prepending the source files with a slash using a config option 'addRootSlash' which is useful in some occasions, and is supported by some other gulp plugins. Please include and publish as a new release to npm. Thx
