### PR TITLE
Issue with `include-self` paths

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -98,7 +98,7 @@ function findMainFiles(config, component, componentConfigFile) {
 
   return filePaths.map(function (file) {
     if (config.get('include-self') && component === config.get('bower.json').name) {
-      return file;
+      return $.path.join(config.get('cwd'), file);
     } else {
       return $.path.join(config.get('bower-directory'), component, file);
     }

--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,6 @@ Options:
   --dependencies      # Include Bower `dependencies`
   --devDependencies   # Include Bower `devDependencies`
   --includeSelf       # Include top-level bower.json `main` files
-  --mainFileDirectory # Specify a path to top-level `main` files
   --verbose           # Print the results of `wiredep`
 ```
 

--- a/test/fixture/cwd_includeself/bower.json
+++ b/test/fixture/cwd_includeself/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "wiredep-test",
+  "version": "0.0.0",
+  "main": [
+    "sample-main.js",
+    "sample-main.css"
+  ],
+  "dependencies": {
+    "bootstrap": "3.0.0"
+  }
+}

--- a/test/fixture/cwd_includeself/bower_components/bootstrap/bower.json
+++ b/test/fixture/cwd_includeself/bower_components/bootstrap/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "bootstrap",
+  "version": "3.0.0",
+  "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css"],
+  "ignore": [
+      "**/.*"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.9.0"
+  }
+}

--- a/test/fixture/cwd_includeself/bower_components/bootstrap/dist/css/bootstrap.css
+++ b/test/fixture/cwd_includeself/bower_components/bootstrap/dist/css/bootstrap.css
@@ -1,0 +1,3 @@
+/**
+ * This file is only for testing purposes.
+**/

--- a/test/fixture/cwd_includeself/bower_components/bootstrap/dist/js/bootstrap.js
+++ b/test/fixture/cwd_includeself/bower_components/bootstrap/dist/js/bootstrap.js
@@ -1,0 +1,3 @@
+/**
+ * This file is only for testing purposes.
+ **/

--- a/test/fixture/cwd_includeself/bower_components/jquery/bower.json
+++ b/test/fixture/cwd_includeself/bower_components/jquery/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "jquery",
+  "version": "2.0.3",
+  "description": "jQuery component",
+  "keywords": [
+    "jquery",
+    "component"
+  ],
+  "main": "jquery.js",
+  "license": "MIT"
+}

--- a/test/fixture/cwd_includeself/bower_components/jquery/jquery.js
+++ b/test/fixture/cwd_includeself/bower_components/jquery/jquery.js
@@ -1,0 +1,3 @@
+/**
+ * This file is only for testing purposes.
+ **/

--- a/test/fixture/cwd_includeself/sample-main.css
+++ b/test/fixture/cwd_includeself/sample-main.css
@@ -1,0 +1,3 @@
+/**
+ * This file is only for testing purposes.
+**/

--- a/test/fixture/cwd_includeself/sample-main.js
+++ b/test/fixture/cwd_includeself/sample-main.js
@@ -1,0 +1,3 @@
+/**
+ * This file is only for testing purposes.
+**/

--- a/test/fixture/html/index-cwd-include-self-actual.html
+++ b/test/fixture/html/index-cwd-include-self-actual.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <link rel="stylesheet" href="../cwd_includeself/bower_components/bootstrap/dist/css/bootstrap.css" />
+  <!-- bower:css -->
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-cwd-include-self-expected.html
+++ b/test/fixture/html/index-cwd-include-self-expected.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <link rel="stylesheet" href="../cwd_includeself/bower_components/bootstrap/dist/css/bootstrap.css" />
+  <!-- bower:css -->
+  <link rel="stylesheet" href="../cwd_includeself/sample-main.css" />
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <script src="../cwd_includeself/bower_components/jquery/jquery.js"></script>
+  <script src="../cwd_includeself/bower_components/bootstrap/dist/js/bootstrap.js"></script>
+  <script src="../cwd_includeself/sample-main.js"></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -289,6 +289,31 @@ describe('wiredep', function () {
 
     assert.equal(filePaths.read('actual'), filePaths.read('expected'));
   });
+
+  it('should support inclusion of main files from bower.json in some other dir', function () {
+    var filePaths = getFilePaths('index-cwd-include-self', 'html');
+
+    wiredep({
+      src: [filePaths.actual],
+      cwd: 'cwd_includeself',
+      includeSelf: true
+    });
+
+    assert.equal(filePaths.read('actual'), filePaths.read('expected'));
+  });
+
+  it('should support inclusion of main files from some other dir with manually loaded bower.json', function () {
+    var filePaths = getFilePaths('index-cwd-include-self', 'html');
+
+    wiredep({
+      bowerJson: JSON.parse(fs.readFileSync('./cwd_includeself/bower.json')),
+      src: [filePaths.actual],
+      cwd: 'cwd_includeself',
+      includeSelf: true
+    });
+
+    assert.equal(filePaths.read('actual'), filePaths.read('expected'));
+  });
 });
 
 function getFilePaths(fileName, fileType) {

--- a/wiredep.js
+++ b/wiredep.js
@@ -21,6 +21,7 @@ function wiredep(opts) {
   config.set
     ('bower.json', opts.bowerJson || JSON.parse($.fs.readFileSync($.path.join(cwd, './bower.json'))))
     ('bower-directory', opts.directory || findBowerDirectory(cwd))
+    ('cwd', cwd)
     ('dependencies', opts.dependencies === false ? false : true)
     ('detectable-file-types', [])
     ('dev-dependencies', opts.devDependencies)


### PR DESCRIPTION
When using `include-self` wiredep always consideres main file paths a relative to `process.cwd()`, so when using `bower.json` from some other `cwd`, it injects invalid paths.
For example, we have the following directory structure:

```
Gruntfile.js
src/
  app/
    app.js
  index.html
stage/
  app/
    app.js
  bower.json
  bower_components
  index.html
```

`Gruntfile.js` contains:

```
wiredep: {
  stage: {
    cwd: 'stage',
    src: 'stage/index.html',
    includeSelf: true
  }
}
```

`bower.json` contains:

```
"main": [
    "app/app.js"
  ]
```

While `bower_components` scripts are injected correctly, self mains are injected as if they are in the root dir, not in `stage`: `<script src="../app/app.js"></script>`
What do I expect to have: `<script src="app/app.js"></script>`

Plus there is `--mainFileDirectory` argument in the `readme.md`, though there isn't any logic for actually processing it, I've also fixed this.
