### PR TITLE
Remove requirement that a dependency is present

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -143,36 +143,38 @@ function gatherInfo(config) {
       }
     }
 
-    var mains = findMainFiles(config, component, componentConfigFile);
-    var fileTypes = _.chain(mains).map($.path.extname).unique().value();
+    if(componentConfigFile) {
+      var mains = findMainFiles(config, component, componentConfigFile);
+      var fileTypes = _.chain(mains).map($.path.extname).unique().value();
+  
+      dep.main = mains;
+      dep.type = fileTypes;
+      dep.name = componentConfigFile.name;
 
-    dep.main = mains;
-    dep.type = fileTypes;
-    dep.name = componentConfigFile.name;
-
-    var depIsExcluded = _.find(config.get('exclude'), function (pattern) {
-      return $.path.join(config.get('bower-directory'), component).match(pattern);
-    });
-
-    if (dep.main.length === 0 && !depIsExcluded) {
-      // can't find the main file. this config file is useless!
-      warnings.push(component + ' was not injected in your file.');
-      warnings.push(
-        'Please go take a look in "'
-        + $.path.join(config.get('bower-directory'), component)
-        + '" for the file you need, then manually include it in your file.');
-
-      config.set('warnings', warnings);
-      return;
+      var depIsExcluded = _.find(config.get('exclude'), function (pattern) {
+        return $.path.join(config.get('bower-directory'), component).match(pattern);
+      });
+  
+      if (dep.main.length === 0 && !depIsExcluded) {
+        // can't find the main file. this config file is useless!
+        warnings.push(component + ' was not injected in your file.');
+        warnings.push(
+          'Please go take a look in "'
+          + $.path.join(config.get('bower-directory'), component)
+          + '" for the file you need, then manually include it in your file.');
+  
+        config.set('warnings', warnings);
+        return;
+      }
+  
+      if (componentConfigFile.dependencies) {
+        dep.dependencies = componentConfigFile.dependencies;
+  
+        _.each(componentConfigFile.dependencies, gatherInfo(config));
+      }
+  
+      config.get('global-dependencies').set(component, dep);
     }
-
-    if (componentConfigFile.dependencies) {
-      dep.dependencies = componentConfigFile.dependencies;
-
-      _.each(componentConfigFile.dependencies, gatherInfo(config));
-    }
-
-    config.get('global-dependencies').set(component, dep);
   };
 }
 


### PR DESCRIPTION
 #24 references a potential use-case.

I have a project where I'm trying to use only PARTS of a bower install in a sub folder. 

```
|--
   | -- bower_components (original)
        |-- bower_package_1
        |-- bower_package_2
        |-- bower_package_3
   | -- sub_project
        |-- bower_components (copied)
            |-- bower_package_1
            |-- bower_package_3
        |-- index.html
   |-- bower.json
   |-- Gruntfile.js
```

In the Gruntfile, I do this:

```
sub_project: {
    directory: 'sub_project/bower_components',
    src: [
      'sub_project/*.html',
      'stylesheets/*.scss'
    ],
    // Optional:
    // ---------
    cwd: 'sub_project',
```

The Gruntfile runs the bower install and then copies the bower packages around using a copy job. I'm hoping to see sub_project/index.html reflect only the parts that are copied in. However, right now your tool will bomb out due to the error:

```
`Cannot read property 'main' of undefined`
```

This happens on line 146 in lib/detect-dependencies.js (see change). The fix is to simply omit this block when the config file isn't found. 

It is a one line change, but may have circumvent purposeful designs. An alternative is to include an or block in that if condition:

```
if(componentConfigFile || config.ensureDependencyInstalled) { 
```

And set that config value to true by default.
