### PR TITLE
Adding Drupal Theme files as a File Types example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,7 @@ require('wiredep')({
     },
     
     drupal: {
-      block: /(([ \t]*);\s*bower:*(\S*)\s*)(\n|\r|.)*?(;\s*endbower\s*)/gi,
+      block: /(([ \t]*);\s*bower:*(\S*))(\n|\r|.)*?(;\s*endbower)/gi,
       detect: {
         js: /<script.*src=['"]([^'"]+)/gi,
         css: /<link.*href=['"]([^'"]+)/gi


### PR DESCRIPTION
[Docs](https://www.drupal.org/node/171205) on Drupal's `.info` files it uses to include JS and CSS
