### PR TITLE
Fixing --src command line option

### DIFF
--- a/wiredep-cli.js
+++ b/wiredep-cli.js
@@ -46,7 +46,7 @@ if (argv.h || argv.help || Object.keys(argv).length === 1) {
   return;
 }
 
-if (!argv.s) {
+if (!argv.s && !argv.src) {
   console.log(chalk.bold.red('> Source file not specified.'));
   console.log('Please pass a `--src path/to/source.html` to `wiredep`.');
   return;


### PR DESCRIPTION
While playing around with the command line interface I found out that using:

``` shell
wiredep --src app/index.html
```

was not really working, only the shorthand: `-s` option was accepted, despite what is documented on `--help`.

This PR fixes that.
