### PR TITLE
Support sub file types

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $ = require('modmod')('fs', 'lodash', 'path', 'propprop');
+var $ = require('modmod')('fs', 'lodash', 'path', 'propprop', 'path-complete-extname');
 var _ = $.lodash;
 
 
@@ -144,7 +144,7 @@ function gatherInfo(config) {
     }
 
     var mains = findMainFiles(config, component, componentConfigFile);
-    var fileTypes = _.chain(mains).map($.path.extname).unique().value();
+    var fileTypes = _.chain(mains).map(findExtname).unique().value();
 
     dep.main = mains;
     dep.type = fileTypes;
@@ -174,6 +174,25 @@ function gatherInfo(config) {
 
     config.get('global-dependencies').set(component, dep);
   };
+
+  /**
+   * Returns a valid extension name of a given filename.
+   *
+   * @param  {string} value  A filename to be used
+   * @return {string} The extension name
+   */
+  function findExtname(value) {
+
+    var completeExtname = $['path-complete-extname'](value);
+
+    if (_.contains(config.get('detectable-file-types'), completeExtname.slice(1))) {
+      return completeExtname;
+    } else {
+      return $.path.extname(value);
+    }
+
+  }
+
 }
 
 
@@ -304,7 +323,8 @@ var eliteDependencies = [
       flatten().
       value().
       filter(function (main) {
-        return $.path.extname(main) === fileType;
+        return $['path-complete-extname'](main) === fileType ||
+          $.path.extname(main) === fileType;
       });
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "minimist": "^1.1.0",
     "modmod": "^0.1.1",
     "propprop": "^0.3.0",
-    "through2": "^0.6.1"
+    "through2": "~0.4.1",
+    "path-complete-extname": "~0.1.0"
   },
   "devDependencies": {
     "fs-extra": "^0.11.0",

--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,33 @@ As an example, this is what your `bower.json` may look like if you wanted to ove
 ```
 
 
+## Sub File Type
+You can define a sub file type in order to wire the same kind of files in multiple placeholders. You can declare extension names containing extra dots in order to do so.
+
+As an example, this would allow you to have a `<!-- bower:min.js -->` section that would place minified javascript files separated from `<!-- bower:js -->`.
+
+
+### Sub file type configuration example
+```js
+require('wiredep')({
+  fileTypes: {
+    html: {
+      detect: {
+        js: /<script.*src=['"]([^'"]+)/gi,
+        css: /<link.*href=['"]([^'"]+)/gi,
+        'min.js': /<script.*src=['"]([^'"]+)/gi,
+      },
+      replace: {
+        js: '<script src="{{filePath}}"></script>',
+        css: '<link rel="stylesheet" href="{{filePath}}" />',
+        'min.js': '<script src="{{filePath}}"></script>'
+      }
+    },
+  }
+});
+```
+
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using `npm test`.
 

--- a/test/fixture/bower_components/fake-package-with-multiple-dot-ext/bower.json
+++ b/test/fixture/bower_components/fake-package-with-multiple-dot-ext/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "fake-package-with-multiple-dot-ext",
+  "version": "1.0.0",
+  "main": [
+      "fake-package.js",
+      "fake-package.notmin.css"
+  ]
+}

--- a/test/fixture/bower_components/fake-package-with-multiple-dot-ext/dist/fake-package.js
+++ b/test/fixture/bower_components/fake-package-with-multiple-dot-ext/dist/fake-package.js
@@ -1,0 +1,3 @@
+(function () {
+  // this should be injected!
+})();

--- a/test/fixture/bower_components/fake-package-with-multiple-dot-ext/dist/fake-package.notmin.css
+++ b/test/fixture/bower_components/fake-package-with-multiple-dot-ext/dist/fake-package.notmin.css
@@ -1,0 +1,3 @@
+.class-definition {
+    color: red;
+}

--- a/test/fixture/bower_packages_with_multiple_dot_ext.json
+++ b/test/fixture/bower_packages_with_multiple_dot_ext.json
@@ -1,0 +1,7 @@
+{
+  "name": "wiredep-test",
+  "version": "0.0.0",
+  "dependencies": {
+    "fake-package-with-multiple-dot-ext": "1.0.0"
+  }
+}

--- a/test/fixture/html/index-with-multiple-dot-extensions-actual.html
+++ b/test/fixture/html/index-with-multiple-dot-extensions-actual.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:notmin.css -->
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-with-multiple-dot-extensions-expected.html
+++ b/test/fixture/html/index-with-multiple-dot-extensions-expected.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:notmin.css -->
+  <link href="../bower_components/fake-package-with-multiple-dot-ext/fake-package.notmin.css" rel="stylesheet">
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <script type="text/javascript" src="../bower_components/fake-package-with-multiple-dot-ext/fake-package.js"></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-without-multiple-dot-extensions-actual.html
+++ b/test/fixture/html/index-without-multiple-dot-extensions-actual.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-without-multiple-dot-extensions-expected.html
+++ b/test/fixture/html/index-without-multiple-dot-extensions-expected.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <link href="../bower_components/fake-package-with-multiple-dot-ext/fake-package.notmin.css" rel="stylesheet">
+  <!-- endbower -->
+</head>
+<body>
+
+  <!-- bower:js -->
+  <script type="text/javascript" src="../bower_components/fake-package-with-multiple-dot-ext/fake-package.js"></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -175,6 +175,46 @@ describe('wiredep', function () {
     }));
   });
 
+  describe('support to multiple dot extension filenames', function () {
+    function testReplaceWithMultipleDotExt(fileTypes, fileName, bowerJsonFile) {
+      return function () {
+        var filePaths = getFilePaths(fileName, 'html');
+
+        wiredep({
+          bowerJson: JSON.parse(fs.readFileSync(bowerJsonFile || './bower.json')),
+          src: [filePaths.actual],
+          fileTypes: fileTypes
+        });
+
+        assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+      };
+    }
+
+    it('should support extensions using multiple dots', testReplaceWithMultipleDotExt({
+      html: {
+        detect: {
+          js: /<script.*src=['"]([^'"]+)/gi,
+          css: /<link.*href=['"]([^'"]+)/gi,
+          'notmin.css': /<link.*href=['"]([^'"]+)/gi
+        },
+        replace: {
+          js: '<script type="text/javascript" src="{{filePath}}"></script>',
+          css: '<link href="{{filePath}}" rel="stylesheet">',
+          'notmin.css': '<link href="{{filePath}}" rel="stylesheet">'
+        }
+      }
+    }, 'index-with-multiple-dot-extensions', './bower_packages_with_multiple_dot_ext.json'));
+
+    it('should ignore multiple dot extensions if no extra detect/replace pattern was provided', testReplaceWithMultipleDotExt({
+      html: {
+        replace: {
+          js: '<script type="text/javascript" src="{{filePath}}"></script>',
+          css: '<link href="{{filePath}}" rel="stylesheet">'
+        }
+      }
+    }, 'index-without-multiple-dot-extensions', './bower_packages_with_multiple_dot_ext.json'));
+  });
+
   describe('devDependencies', function () {
     it('should wire devDependencies if specified', function () {
       var filePaths = getFilePaths('index-with-dev-dependencies', 'html');


### PR DESCRIPTION
This PR implements a way of declaring different placeholders for the same kind of files.
## Reasoning

Bower [main property has been a struggle](https://github.com/bower/bower/issues/935) for a very very long time and it's unlikely that is [ever going to change](https://github.com/bower/bower.json-spec/issues/20). Meanwhile, the [Bower spec](https://github.com/bower/bower.json-spec) only specifies one way of consuming the required files from a package, using the **main** property.

Up until now, the way **wiredep** is working around the limitation of assets definition on Bower packages is by figuring out file types by their extension name and defining placeholders for each of them. This solution has been working great for simple cases but in some environments we really need to differentiate one kind of js file from another or have two different placeholders for css files for instance.
### The ie stylesheet limit problem

Our beloved _ie9_ has [very low limits on stylesheet files](http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/10164546.aspx) and in some situations we need to separate some css files from the minify build. In the actual implementation there is not a way of achieving such separation when using wiredep.
## The proposed solution

The solution implemented by this PR extends the file extension detection to allow package publishers to define a sub file type in order to _wiredep_ them into different placeholders.

In order to fix the issue in the _ie9 limit_ example, a package author with a very large css file could rename it to `style.notmin.css` that would be placed inside the `<!-- bower:notmin.css -->` placeholder. Allowing the user to keep using `<!-- bower:css -->` along with usemin and his other css files.
### Requirements

The only extra step required by the users in order to use a "sub file type" is declaring both the **detect**/**replace** patterns for the new type.
## Conclusion

This is an incremental change only that should be 100% backwards compatible. Any user not interested on defining sub file types would never be affected in any way - _in fact, the changes to the actual code are minor, a dozen lines or so_.

I see this as an essential addition for **wiredep** - thus the reason of such a detailed description. Sorry if it got too long.
