### PR TITLE
Change double quote to single quote in scss

### DIFF
--- a/lib/default-file-types.js
+++ b/lib/default-file-types.js
@@ -57,9 +57,9 @@ module.exports = {
       scss: /@import\s['"](.+scss)['"]/gi
     },
     replace: {
-      css: '@import "{{filePath}}";',
-      sass: '@import "{{filePath}}";',
-      scss: '@import "{{filePath}}";'
+      css: '@import \'{{filePath}}\';',
+      sass: '@import \'{{filePath}}\';',
+      scss: '@import \'{{filePath}}\';'
     }
   },
 


### PR DESCRIPTION
Change double quote to single quote in scss replacement to avoid linting errors in css
