### PR TITLE
Add chalk to dependencies for wiredep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bower-config": "^0.5.0",
+    "chalk": "^0.5.1",
     "glob": "^4.0.5",
     "lodash": "^2.4.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
Turns out `chalk` isn't always installed by default.
