### PR TITLE
Add Chai as a devDependency for better AssertionError messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "through2": "^0.6.1"
   },
   "devDependencies": {
+    "chai": "^1.10.0",
     "fs-extra": "^0.11.0",
     "jshint": "*",
     "mocha": "*"

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -5,7 +5,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
-var assert = require('assert');
+var assert = require('chai').assert;
 var wiredep = require('../wiredep');
 
 describe('wiredep', function () {
@@ -20,7 +20,10 @@ describe('wiredep', function () {
 
         wiredep({ src: [filePaths.actual] });
 
-        assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+        assert.deepEqual(
+          filePaths.read('expected').split('\n'),
+          filePaths.read('actual').split('\n')
+        );
       };
     }
 


### PR DESCRIPTION
I've always found the failure messages in Chai to be superior to `node.assert`, especially when dealing with collections. Chai uses `diff` to produce much more readable output when `assert.deepEqual` fails, for one.

Since this change wasn't particularly related to the original in #128, I opened a separate PR for it, but the branch is still based on `al-the-x:patch-1`. Can rebase as needed.