### PR TITLE
unbuffered comments support for Jade

### DIFF
--- a/lib/default-file-types.js
+++ b/lib/default-file-types.js
@@ -30,7 +30,7 @@ module.exports = {
   },
 
   jade: {
-    block: regex.block['//'],
+    block: /(([ \t]*)\/\/-?\s*bower:*(\S*))(\n|\r|.)*?(\/\/-?\s*endbower)/gi,
     detect: {
       js: /script\(.*src=['"]([^'"]+)/gi,
       css: /link\(.*href=['"]([^'"]+)/gi

--- a/test/fixture/jade/index-unbuffered-comments-actual.jade
+++ b/test/fixture/jade/index-unbuffered-comments-actual.jade
@@ -1,0 +1,12 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  script(src='../bower_components/modernizr/modernizr.js')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  //- bower:css
+  //- endbower
+  body
+    //- bower:js
+    //- endbower

--- a/test/fixture/jade/index-unbuffered-comments-expected.jade
+++ b/test/fixture/jade/index-unbuffered-comments-expected.jade
@@ -1,0 +1,16 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  script(src='../bower_components/modernizr/modernizr.js')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  //- bower:css
+  link(rel='stylesheet', href='../bower_components/codecode/dist/codecode.css')
+  //- endbower
+  body
+    //- bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/codecode/dist/codecode.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    //- endbower

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -25,7 +25,16 @@ describe('wiredep', function () {
     }
 
     it('should work with html files', testReplace('html'));
-    it('should work with jade files', testReplace('jade'));
+    it('should work with jade files (buffered comments)', testReplace('jade'));
+
+    it('should work with jade files (unbuffered comments)', function () {
+      var filePaths = getFilePaths('index-unbuffered-comments', 'jade');
+
+      wiredep({ src: [filePaths.actual] });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
+
     it('should work with sass files', testReplace('sass'));
     it('should work with scss files', testReplace('scss'));
     it('should work with yml files', testReplace('yml'));


### PR DESCRIPTION
Jade supports [two types of comments](http://jade-lang.com/reference/comments/):

``` jade
// This is a buffered comment, it will appear as <!-- ... --> in your HTML
//- This is an unbuffered comment, it will not appear in your HTML
```

However,

``` jade
// This is supported by wiredep:
// bower:js
// endbower

// This is not:
//- bower:js
//- endbower
```

wiredep allows us to use a custom regexp in order to support the latter, but it is not very convenient imho.

I added the ability to use both types of comments by default, so we can use unbuffered comments and be consistent with [gulp-inject](/klei/gulp-inject).
