### PR TITLE
support routes for url rewriting

### DIFF
--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -58,6 +58,7 @@ function replaceIncludes(file, fileType, returnType) {
     var newFileContents = startBlock;
     var dependencies = globalDependenciesSorted[blockType] || [];
     var quoteMark = '';
+    var routes = config.get('routes');
 
     (string.substr(0, offset) + string.substr(offset + match.length)).
       replace(oldScripts, '').
@@ -82,6 +83,15 @@ function replaceIncludes(file, fileType, returnType) {
           $.path.relative($.path.dirname(file), $.path.dirname(filePath)),
           $.path.basename(filePath)
         ).replace(/\\/g, '/').replace(ignorePath, '');
+      }).
+      map(function (filePath) {
+        for (var route in routes) {
+          if (filePath.indexOf(route) === 0) {
+            return filePath.replace(route, routes[route]);
+          }
+        }
+
+        return filePath;
       }).
       filter(function (filePath) {
         return filesCaught.indexOf(filePath) === -1;

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,10 @@ require('wiredep')({
     // pkg = 'name-of-bower-package-without-main'
   },
 
+  routes: {
+    // "../bower_components": "/lib"
+  }
+
   fileTypes: {
     fileExtension: {
       block: /match the beginning-to-end of a bower block in this type of file/,

--- a/test/fixture/html/index-with-routes-actual.html
+++ b/test/fixture/html/index-with-routes-actual.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <!-- endbower -->
+</head>
+<body>
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-with-routes-expected.html
+++ b/test/fixture/html/index-with-routes-expected.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <link rel="stylesheet" href="/lib/codecode/dist/codecode.css" />
+  <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap.css" />
+  <!-- endbower -->
+</head>
+<body>
+  <!-- bower:js -->
+  <script src="/lib/jquery/jquery.js"></script>
+  <script src="/lib/modernizr/modernizr.js"></script>
+  <script src="/lib/codecode/dist/codecode.js"></script>
+  <script src="/lib/bootstrap/dist/js/bootstrap.js"></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -278,6 +278,21 @@ describe('wiredep', function () {
     });
   });
 
+  describe('routes', function () {
+    it('should do url rewriting if asked', function () {
+      var filePaths = getFilePaths('index-with-routes', 'html');
+
+      wiredep({
+        src: [filePaths.actual],
+        routes: {
+          "../bower_components": "/lib"
+        }
+      });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
+  });
+
   describe('events', function() {
     var filePath = 'html/index-emitter.html';
     var fileData;

--- a/wiredep.js
+++ b/wiredep.js
@@ -45,6 +45,7 @@ function wiredep(opts) {
     ('ignore-path', opts.ignorePath)
     ('include-self', opts.includeSelf)
     ('overrides', $._.extend({}, config.get('bower.json').overrides, opts.overrides))
+    ('routes', opts.routes || {})
     ('src', [])
     ('stream', opts.stream ? opts.stream : {});
 


### PR DESCRIPTION
This commit adds support for routes in the injected filepaths. Can be useful if a templating engine (Jade, HAML, etc.) is _wired_ before compilation and output in another folder.

```
bower_components/   <- libraries
views/              <- Jade files
public/             <- HTTP server root, serves HTML files and assets
  lib/              <- main Bower files
```

Without routes, the HTML files point to `../bower_components/<path>`, when I need them to point to `/lib/<path>`.

We can work this out with a custom replace function, but I think routes add some flexibility to this.
