### PR TITLE
fix issue #107: throw error when component is not found

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -139,6 +139,9 @@ function gatherInfo(config) {
     };
 
     var componentConfigFile = findComponentConfigFile(config, component);
+    if (componentConfigFile === undefined) {
+      throw new Error(component + ' is not installed. Try running `bower install`.');
+    }
 
     var overrides = config.get('overrides');
 

--- a/test/fixture/bower_with_missing_component.json
+++ b/test/fixture/bower_with_missing_component.json
@@ -1,0 +1,7 @@
+{
+  "name": "wiredep-test",
+  "version": "0.0.0",
+  "dependencies": {
+    "missing-component": "1.0.0"
+  }
+}

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -334,6 +334,22 @@ describe('wiredep', function () {
         }
       });
     });
+
+    it('should throw an error when component is not found', function(done) {
+      var bowerJson = JSON.parse(fs.readFileSync('./bower_with_missing_component.json'));
+      var missingComponent = 'missing-component';
+
+      try {
+        wiredep({
+          bowerJson: bowerJson,
+          src: filePath
+        });
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, missingComponent+' is not installed. Try running `bower install`.');
+        done();
+      }
+    });
   });
 
   it('should allow specifying a custom replace function', function () {


### PR DESCRIPTION
see issue #107.
see pull request #137.

Folks can run into issue #107 when they are missing some of the dependencies
that are supposed to be installed with `bower install`. The trick there
is that **some** of the dependencies are installed, otherwise it would fail
with a different error (e.g. cannot find `bower_components`). I can reproduce
the error consistently by cloning a repo at a previous revision, running
`bower install` then doing a `git pull` which changes the list of dependencies
that should be installed and running `grunt wiredep`.

If you are part of a big organization where many folks could be updating
bower dependencies and folks don't run `bower install` religiously after a
`git pull`, then you could run into issue #107 more often.

The difference between this pull request and pull request #137 is that
the latter one allows to configure the error handler when a component is not
found; which may be useful in situations where `wiredep` is called by higher
level tools and you want e.g. to customize the error message.
