### PR TITLE
more helpful missing component error message - in case the component is not needed

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -140,7 +140,7 @@ function gatherInfo(config) {
 
     var componentConfigFile = findComponentConfigFile(config, component);
     if (!componentConfigFile) {
-      var error = new Error(component + ' is not installed. Try running `bower install`.');
+      var error = new Error(component + ' is not installed. Try running `bower install` or remove the component from your bower.json file.');
       error.code = 'PKG_NOT_INSTALLED';
       config.get('on-error')(error);
       return;

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -356,7 +356,7 @@ describe('wiredep', function () {
         src: filePath,
         onError: function(err) {
           assert.ok(err instanceof Error);
-          assert.equal(err.message, missingComponent + ' is not installed. Try running `bower install`.');
+          assert.equal(err.message, missingComponent + ' is not installed. Try running `bower install` or remove the component from your bower.json file.');
           done();
         }
       });


### PR DESCRIPTION
Currently, after #139 - the error message for missing component is more helpful but it assumes you want this dependency. This PR updates the message to hint with how to deal with the situation where you don't want this component.

I understand that error messages are not meant to give instructions for proper use, but in this case even after the more helpful message added in #139 it is not clear why wiredep is failing when you uninstall a component.

Reproduce steps:
* Given you have a bower.json file with some dependencies
* You then uninstall a dependency using bower uninstall or manually remove from bower_components
* But - you forgot to update your bower.json (with --save or manually)
* You then run wiredep