### PR TITLE
Add support for HTML imports

### DIFF
--- a/lib/default-file-types.js
+++ b/lib/default-file-types.js
@@ -9,14 +9,16 @@ module.exports = {
     block: /(([ \t]*)<!--\s*bower:*(\S*)\s*-->)(\n|\r|.)*?(<!--\s*endbower\s*-->)/gi,
     detect: {
       js: /<script.*src=['"]([^'"]+)/gi,
-      css: /<link.*href=['"]([^'"]+)/gi
+      css: /<link.*href=['"]([^'"]+)/gi,
+      html: /<link.*href=['"]([^'"]+)/gi
     },
     replace: {
       js: '<script src="{{filePath}}"></script>',
-      css: '<link rel="stylesheet" href="{{filePath}}" />'
+      css: '<link rel="stylesheet" href="{{filePath}}" />',
+      html: '<link rel="import" href="{{filePath}}" />'
     }
   },
-  
+
   js: {
     block: regex.block['//'],
     detect: {
@@ -33,11 +35,13 @@ module.exports = {
     block: /(([ \t]*)\/\/-?\s*bower:*(\S*))(\n|\r|.)*?(\/\/-?\s*endbower)/gi,
     detect: {
       js: /script\(.*src=['"]([^'"]+)/gi,
-      css: /link\(.*href=['"]([^'"]+)/gi
+      css: /link\(.*href=['"]([^'"]+)/gi,
+      html: /link\(.*href=['"]([^'"]+)/gi
     },
     replace: {
       js: 'script(src=\'{{filePath}}\')',
-      css: 'link(rel=\'stylesheet\', href=\'{{filePath}}\')'
+      css: 'link(rel=\'stylesheet\', href=\'{{filePath}}\')',
+      html: 'link(rel=\'import\', href=\'{{filePath}}\')'
     }
   },
 
@@ -45,11 +49,13 @@ module.exports = {
     block: /(([ \t]*)\/!?\s*bower:(\S*))(\n|\r|.)*?(\/!?\s*endbower)/gi,
     detect: {
       js: /script.*src=['"]([^'"]+)/gi,
-      css: /link.*href=['"]([^'"]+)/gi
+      css: /link.*href=['"]([^'"]+)/gi,
+      html: /link.*href=['"]([^'"]+)/gi
     },
     replace: {
       js: 'script src=\'{{filePath}}\'',
-      css: 'link rel=\'stylesheet\' href=\'{{filePath}}\''
+      css: 'link rel=\'stylesheet\' href=\'{{filePath}}\'',
+      html: 'link rel=\'import\' href=\'{{filePath}}\''
     }
   },
 
@@ -109,11 +115,13 @@ module.exports = {
     block: /(([ \t]*)#\s*bower:*(\S*))(\n|\r|.)*?(#\s*endbower)/gi,
     detect: {
       js: /-\s(.+js)/gi,
-      css: /-\s(.+css)/gi
+      css: /-\s(.+css)/gi,
+      html: /-\s(.+html)/gi
     },
     replace: {
       js: '- {{filePath}}',
-      css: '- {{filePath}}'
+      css: '- {{filePath}}',
+      html: '- {{filePath}}'
     }
   },
 
@@ -121,11 +129,13 @@ module.exports = {
     block: /(([ \t]*)-#\s*bower:*(\S*))(\n|\r|.)*?(-#\s*endbower)/gi,
     detect: {
       js: /\%script\{.*src:['"]([^'"]+)/gi,
-      css: /\%link\{.*href:['"]([^'"]+)/gi
+      css: /\%link\{.*href:['"]([^'"]+)/gi,
+      html: /\%link\{.*href:['"]([^'"]+)/gi
     },
     replace: {
       js: '%script{src:\'{{filePath}}\'}',
-      css: '%link{rel:\'stylesheet\', href:\'{{filePath}}\'}'
+      css: '%link{rel:\'stylesheet\', href:\'{{filePath}}\'}',
+      html: '%link{rel:\'import\', href:\'{{filePath}}\'}'
     }
   }
 };

--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -85,7 +85,7 @@ function findComponentConfigFile(config, component) {
  */
 function findMainFiles(config, component, componentConfigFile) {
   var filePaths = [];
-  var file;
+  var file = {};
   var self = config.get('include-self') && component === config.get('bower.json').name;
   var cwd = self ? config.get('cwd') : $.path.join(config.get('bower-directory'), component);
 
@@ -98,10 +98,18 @@ function findMainFiles(config, component, componentConfigFile) {
     // still haven't found it. is it stored in config.scripts, then?
     filePaths = componentConfigFile.scripts;
   } else {
-    file = $.path.join(config.get('bower-directory'), component, componentConfigFile.name + '.js');
-    if ($.fs.existsSync(file)) {
-      filePaths = [componentConfigFile.name + '.js'];
-    }
+    ['html', 'js'].
+      forEach(function (type) {
+        file[type] = $.path.join(config.get('bower-directory'), component, componentConfigFile.name + '.' + type);
+      });
+
+      if ($.fs.existsSync(file['html'])) {
+        filePaths = [componentConfigFile.name + '.html'];
+      } else {
+        if ($.fs.existsSync(file['js'])) {
+          filePaths = [componentConfigFile.name + '.js'];
+        }
+      }
   }
 
   return $._.unique(filePaths.reduce(function (acc, filePath) {


### PR DESCRIPTION
http://www.html5rocks.com/en/tutorials/webcomponents/imports/

Web Components are pretty popular lately, so why not add support for HTML imports?

From what I've seen, most or all of Polymer's component don't have a `main` field specified, so I also added a fallback just like for JS files, which should work in most cases.

My idea is to make wiredep follow HTML imports and exclude assets that those HTML files already include, like it does with source HTML files, but I haven't implemented that yet.

What do you think about all of this?

I'll add tests after I know how (or whether) to proceed.