### PR TITLE
Ability to include a property or list of properties in your own bower.js...

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -162,6 +162,20 @@ function gatherInfo(config) {
       }
     }
 
+    var include = config.get('include');
+
+    if (include && include[component]) {
+      if (include[component].main) {
+        if ($._.isString(include[component].main)) {
+          componentConfigFile.main.push(include[component].main);
+        } else if ($._.isArray(include[component].main)) {
+          $._.each(include[component].main, function(component) {
+            componentConfigFile.main.push(component);
+          });
+        }
+      }
+    }
+
     var mains = findMainFiles(config, component, componentConfigFile);
     var fileTypes = $._.chain(mains).map($.path.extname).unique().value();
 

--- a/readme.md
+++ b/readme.md
@@ -188,9 +188,16 @@ require('wiredep')({
     // modifying your project's `bower.json` isn't an option.
   },
 
+  includes: {
+    // see `Bower Includes` section below.
+    //
+    // This inline object offers a way to include files if modifying your
+    // project's `bower.json` isn't an option.
+  },
+
   onError: function(err) {
     // If not overridden, an error will throw.
-    
+
     // err = Error object.
     // err.code can be:
     //   - "PKG_NOT_INSTALLED" (a Bower package was not found)
@@ -330,6 +337,28 @@ As an example, this is what your `bower.json` may look like if you wanted to ove
   "overrides": {
     "package-without-main": {
       "main": "dist/package-without-main.js"
+    }
+  }
+}
+```
+
+
+## Bower Include
+To include a property, or list of properties, in one of your dependency's
+`bower.json` file, you may specify an `include` object in your own `bower.json`.
+
+As an example, this is what your `bower.json` may look like if you wanted to
+override `package`'s `main` file:
+
+```js
+{
+  ...
+  "dependencies": {
+    "package": "1.0.0"
+  },
+  "include": {
+    "package": {
+      "main": "theme/package-theme.css"
     }
   }
 }

--- a/test/fixture/bower_components/fake-package/bower.json
+++ b/test/fixture/bower_components/fake-package/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-package",
+  "version": "1.0.0",
+  "main": ["dist/fake-javascript.js", "dist/fake-stylesheet.css"]
+}

--- a/test/fixture/bower_components/fake-package/dist/fake-javascript.js
+++ b/test/fixture/bower_components/fake-package/dist/fake-javascript.js
@@ -1,0 +1,3 @@
+(function () {
+  // this should be injected!
+})();

--- a/test/fixture/bower_components/fake-package/dist/fake-stylesheet.css
+++ b/test/fixture/bower_components/fake-package/dist/fake-stylesheet.css
@@ -1,0 +1,3 @@
+body {
+  /* this should be injected! */
+}

--- a/test/fixture/bower_components/fake-package/themes/fake-theme.css
+++ b/test/fixture/bower_components/fake-package/themes/fake-theme.css
@@ -1,0 +1,3 @@
+body {
+  /* this should be injected! */
+}

--- a/test/fixture/bower_packages_with_include.json
+++ b/test/fixture/bower_packages_with_include.json
@@ -1,0 +1,14 @@
+{
+  "name": "wiredep-test",
+  "version": "0.0.0",
+  "dependencies": {
+    "codecode": "0.0.3",
+    "bootstrap": "3.0.0",
+    "fake-package": "1.0.0"
+  },
+  "include": {
+    "fake-package": {
+      "main": ["themes/fake-theme.css"]
+    }
+  }
+}

--- a/test/fixture/html/index-include-actual.html
+++ b/test/fixture/html/index-include-actual.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <link rel="stylesheet" href="../bower_components/codecode/dist/codecode.css" />
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="../bower_components/fake-package/dist/fake-stylesheet.css" />
+  <!-- endbower -->
+  </head>
+<body>
+
+  <!-- bower:js -->
+  <script src="../bower_components/jquery/jquery.js"></script>
+  <script src="../bower_components/codecode/dist/codecode.js"></script>
+  <script src="../bower_components/bootstrap/dist/js/bootstrap.js"></script>
+  <script src="../bower_components/fake-package/dist/fake-javascript.js"></script>
+  <!-- endbower -->
+  </body>
+</html>

--- a/test/fixture/html/index-include-expected.html
+++ b/test/fixture/html/index-include-expected.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>test.</title>
+  <!-- bower:css -->
+  <link rel="stylesheet" href="../bower_components/codecode/dist/codecode.css" />
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="../bower_components/fake-package/dist/fake-stylesheet.css" />
+  <link rel="stylesheet" href="../bower_components/fake-package/themes/fake-theme.css" />
+  <!-- endbower -->
+  </head>
+<body>
+
+  <!-- bower:js -->
+  <script src="../bower_components/jquery/jquery.js"></script>
+  <script src="../bower_components/codecode/dist/codecode.js"></script>
+  <script src="../bower_components/bootstrap/dist/js/bootstrap.js"></script>
+  <script src="../bower_components/fake-package/dist/fake-javascript.js"></script>
+  <!-- endbower -->
+  </body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -281,6 +281,23 @@ describe('wiredep', function () {
     });
   });
 
+  describe('include', function() {
+    it('should allow configuration include to specify a `main`', function() {
+      var filePaths = getFilePaths('index-include', 'html');
+      var bowerJson = JSON.parse(fs.readFileSync('./bower_packages_with_include.json'));
+      var include = bowerJson.include;
+      delete bowerJson.include;
+
+      wiredep({
+        bowerJson: bowerJson,
+        include: include,
+        src: [filePaths.actual]
+      });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
+  });
+
   describe('events', function() {
     var filePath = 'html/index-emitter.html';
     var fileData;

--- a/wiredep.js
+++ b/wiredep.js
@@ -45,6 +45,7 @@ function wiredep(opts) {
     ('ignore-path', opts.ignorePath)
     ('include-self', opts.includeSelf)
     ('overrides', $._.extend({}, config.get('bower.json').overrides, opts.overrides))
+    ('include', $._.extend({}, config.get('bower.json').include, opts.include))
     ('src', [])
     ('stream', opts.stream ? opts.stream : {});
 


### PR DESCRIPTION
... file.

This may be used in case you do not wish to override a package's bower.js main property, but simply include other files (such as themes) with it.