### PR TITLE
Add prefix and rootDirectory options

### DIFF
--- a/lib/inject-dependencies.js
+++ b/lib/inject-dependencies.js
@@ -75,10 +75,15 @@ function replaceIncludes(file, fileType, returnType) {
 
     dependencies.
       map(function (filePath) {
-        return $.path.join(
-          $.path.relative($.path.dirname(file), $.path.dirname(filePath)),
-          $.path.basename(filePath)
-        ).replace(/\\/g, '/').replace(ignorePath, '');
+        var prefix = config.get('prefix');
+        var rootDir = config.get('root-directory');
+        return prefix +
+          $.path.join(
+            $.path.relative(
+              $.path.join($.path.dirname(file), rootDir),
+              $.path.dirname(filePath)),
+            $.path.basename(filePath)
+          ).replace(/\\/g, '/').replace(ignorePath, '');
       }).
       forEach(function (filePath) {
         if (typeof fileType.replace[blockType] === 'function') {

--- a/test/fixture/html/index-add-prefix-actual.html
+++ b/test/fixture/html/index-add-prefix-actual.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>test.</title>
+  <!-- bower:css -->
+  <!-- endbower -->
+</head>
+<body>
+
+  <script src='not/a/real/thing.js'></script>
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-add-prefix-expected.html
+++ b/test/fixture/html/index-add-prefix-expected.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>test.</title>
+  <!-- bower:css -->
+  <link rel="stylesheet" href="/plugins/codecode/dist/codecode.css" />
+  <link rel="stylesheet" href="/plugins/bootstrap/dist/css/bootstrap.css" />
+  <!-- endbower -->
+</head>
+<body>
+
+  <script src='not/a/real/thing.js'></script>
+  <!-- bower:js -->
+  <script src='/plugins/jquery/jquery.js'></script>
+  <script src='/plugins/codecode/dist/codecode.js'></script>
+  <script src='/plugins/bootstrap/dist/js/bootstrap.js'></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-change-root-directory-actual.html
+++ b/test/fixture/html/index-change-root-directory-actual.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>test.</title>
+  <!-- bower:css -->
+  <!-- endbower -->
+</head>
+<body>
+
+  <script src='not/a/real/thing.js'></script>
+  <!-- bower:js -->
+  <!-- endbower -->
+</body>
+</html>

--- a/test/fixture/html/index-change-root-directory-expected.html
+++ b/test/fixture/html/index-change-root-directory-expected.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>test.</title>
+  <!-- bower:css -->
+  <link rel="stylesheet" href="codecode/dist/codecode.css" />
+  <link rel="stylesheet" href="bootstrap/dist/css/bootstrap.css" />
+  <!-- endbower -->
+</head>
+<body>
+
+  <script src='not/a/real/thing.js'></script>
+  <!-- bower:js -->
+  <script src='jquery/jquery.js'></script>
+  <script src='codecode/dist/codecode.js'></script>
+  <script src='bootstrap/dist/js/bootstrap.js'></script>
+  <!-- endbower -->
+</body>
+</html>

--- a/test/wiredup_test.js
+++ b/test/wiredup_test.js
@@ -66,6 +66,29 @@ describe('wiredep', function () {
       assert.equal(filePaths.read('expected'), filePaths.read('actual'));
     });
 
+    it('should correctly change root directory', function () {
+      var filePaths = getFilePaths('index-change-root-directory', 'html');
+
+      wiredep({
+        src: [filePaths.actual],
+        rootDir: '../bower_components/'
+      });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
+
+    it('should correctly add a prefix to the URL', function () {
+      var filePaths = getFilePaths('index-add-prefix', 'html');
+
+      wiredep({
+        src: [filePaths.actual],
+        rootDir: '../bower_components/',
+        prefix: '/plugins/'
+      });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
+
     it('should support globbing', function () {
       wiredep({ src: ['html/index-actual.*', 'jade/index-actual.*', 'slim/index-actual.*', 'haml/index-actual.*'] });
 

--- a/wiredep.js
+++ b/wiredep.js
@@ -44,6 +44,8 @@ function wiredep(opts) {
     ('global-dependencies', helpers.createStore())
     ('ignore-path', opts.ignorePath)
     ('include-self', opts.includeSelf)
+    ('root-directory', opts.rootDir || './')
+    ('prefix', opts.prefix || '')
     ('overrides', $._.extend({}, config.get('bower.json').overrides, opts.overrides))
     ('src', [])
     ('stream', opts.stream ? opts.stream : {});


### PR DESCRIPTION
I need to set a rootDirectory variable because I generate my HTML from a jade/ directory and put them in a build/ directory, but the root of my public server is on build/, so it actually generate URL like "../build/<correct path>"

Also, I'd like to be able to set a prefix to my URL, like "/<correct path>" or "/plugins/<correct path>" for example.