### PR TITLE
added support for pugjs (previously known as jade)

### DIFF
--- a/lib/default-file-types.js
+++ b/lib/default-file-types.js
@@ -41,6 +41,18 @@ module.exports = {
     }
   },
 
+  pug: {
+    block: /(([ \t]*)\/\/-?\s*bower:*(\S*))(\n|\r|.)*?(\/\/-?\s*endbower)/gi,
+    detect: {
+      js: /script\(.*src=['"]([^'"]+)/gi,
+      css: /link\(.*href=['"]([^'"]+)/gi
+    },
+    replace: {
+      js: 'script(src=\'{{filePath}}\')',
+      css: 'link(rel=\'stylesheet\', href=\'{{filePath}}\')'
+    }
+  },
+
   slim: {
     block: /(([ \t]*)\/!?\s*bower:(\S*))(\n|\r|.)*?(\/!?\s*endbower)/gi,
     detect: {

--- a/test/fixture/pug/index-actual.pug
+++ b/test/fixture/pug/index-actual.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  // endbower
+  body
+    // bower:js
+    // endbower

--- a/test/fixture/pug/index-after-uninstall-actual.pug
+++ b/test/fixture/pug/index-after-uninstall-actual.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  // endbower
+  body
+    // bower:js
+    // endbower

--- a/test/fixture/pug/index-after-uninstall-all-actual.pug
+++ b/test/fixture/pug/index-after-uninstall-all-actual.pug
@@ -1,0 +1,13 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-after-uninstall-all-expected.pug
+++ b/test/fixture/pug/index-after-uninstall-all-expected.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  // endbower
+  body
+    // bower:js
+    // endbower

--- a/test/fixture/pug/index-after-uninstall-expected.pug
+++ b/test/fixture/pug/index-after-uninstall-expected.pug
@@ -1,0 +1,13 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-custom-format-actual.pug
+++ b/test/fixture/pug/index-custom-format-actual.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  // endbower
+  body
+    // bower:js
+    // endbower

--- a/test/fixture/pug/index-custom-format-expected.pug
+++ b/test/fixture/pug/index-custom-format-expected.pug
@@ -1,0 +1,15 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(href='../bower_components/codecode/dist/codecode.css', rel='stylesheet')
+  link(href='../bower_components/bootstrap/dist/css/bootstrap.css', rel='stylesheet')
+  // endbower
+  body
+    // bower:js
+    script(type='text/javascript', src='../bower_components/jquery/jquery.js')
+    script(type='text/javascript', src='../bower_components/codecode/dist/codecode.js')
+    script(type='text/javascript', src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-excluded-files-actual.pug
+++ b/test/fixture/pug/index-excluded-files-actual.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  // endbower
+  body
+    // bower:js
+    // endbower

--- a/test/fixture/pug/index-excluded-files-expected.pug
+++ b/test/fixture/pug/index-excluded-files-expected.pug
@@ -1,0 +1,12 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    // endbower

--- a/test/fixture/pug/index-expected.pug
+++ b/test/fixture/pug/index-expected.pug
@@ -1,0 +1,15 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/codecode/dist/codecode.css')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/codecode/dist/codecode.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-second-run-actual.pug
+++ b/test/fixture/pug/index-second-run-actual.pug
@@ -1,0 +1,15 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/codecode/dist/codecode.css')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/codecode/dist/codecode.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-second-run-expected.pug
+++ b/test/fixture/pug/index-second-run-expected.pug
@@ -1,0 +1,15 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  // bower:css
+  link(rel='stylesheet', href='../bower_components/codecode/dist/codecode.css')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  // endbower
+  body
+    // bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/codecode/dist/codecode.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    // endbower

--- a/test/fixture/pug/index-unbuffered-comments-actual.pug
+++ b/test/fixture/pug/index-unbuffered-comments-actual.pug
@@ -1,0 +1,10 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  //- bower:css
+  //- endbower
+  body
+    //- bower:js
+    //- endbower

--- a/test/fixture/pug/index-unbuffered-comments-expected.pug
+++ b/test/fixture/pug/index-unbuffered-comments-expected.pug
@@ -1,0 +1,15 @@
+!!! 5
+html(lang='en')
+head
+  meta(charset='utf-8')
+  title test.
+  //- bower:css
+  link(rel='stylesheet', href='../bower_components/codecode/dist/codecode.css')
+  link(rel='stylesheet', href='../bower_components/bootstrap/dist/css/bootstrap.css')
+  //- endbower
+  body
+    //- bower:js
+    script(src='../bower_components/jquery/jquery.js')
+    script(src='../bower_components/codecode/dist/codecode.js')
+    script(src='../bower_components/bootstrap/dist/js/bootstrap.js')
+    //- endbower

--- a/test/wiredep_test.js
+++ b/test/wiredep_test.js
@@ -67,6 +67,15 @@ describe('wiredep', function () {
       assert.equal(filePaths.read('expected'), filePaths.read('actual'));
     });
 
+    it('should work with pug files (buffered comments)', testReplace('pug'));
+
+    it('should work with pug files (unbuffered comments)', function () {
+      var filePaths = getFilePaths('index-unbuffered-comments', 'pug');
+
+      wiredep({ src: [filePaths.actual] });
+
+      assert.equal(filePaths.read('expected'), filePaths.read('actual'));
+    });
     it('should work with sass files', testReplace('sass'));
     it('should work with scss files', testReplace('scss'));
     it('should work with yml files', testReplace('yml'));


### PR DESCRIPTION
As mentioned [here](https://github.com/pugjs/pug/issues/2184), Jade was renamed to Pug. This also means that in the future, `*.jade` files will be renamed to `*.pug`.

This pull request contains the updates necessary to support `*.pug` files in the same way as `*.jade`. Even though `*.jade` files may be gone at some point, we will need to continue to support them as well in the future, for compatibility reasons.
