### PR TITLE
Defaults changed by configuration

### DIFF
--- a/test/wiredep_test.js
+++ b/test/wiredep_test.js
@@ -1,38 +1,14 @@
 /*jshint latedef:false */
-/*global after, afterEach, describe, it, before, beforeEach */
+/*global after, describe, it, before, beforeEach */
 
 'use strict';
 
 var fs = require('fs-extra');
 var path = require('path');
 var assert = require('chai').assert;
-var wiredep;
-
-require.uncache = function (moduleName) {
-  var mod = require.resolve(moduleName);
-  if (mod && ((mod = require.cache[mod]) !== undefined)) {
-    (function run(mod) {
-      mod.children.forEach(function (child) {
-        run(child);
-      });
-      delete require.cache[mod.id];
-    })(mod);
-  }
-
-  Object.keys(module.constructor._pathCache).forEach(function(cacheKey) {
-    if (cacheKey.indexOf(moduleName)>0) {
-      delete module.constructor._pathCache[cacheKey];
-    }
-  });
-};
+var wiredep = require('../wiredep');
 
 describe('wiredep', function () {
-  beforeEach(function () {
-    wiredep = require('../wiredep');
-  });
-  afterEach(function () {
-    require.uncache('../wiredep');
-  });
   before(function() {
     fs.copySync('test/fixture', '.tmp');
     process.chdir('.tmp');

--- a/test/wiredep_test.js
+++ b/test/wiredep_test.js
@@ -1,5 +1,5 @@
 /*jshint latedef:false */
-/*global after, describe, it, before, beforeEach */
+/*global after, afterEach, describe, it, before, beforeEach */
 
 'use strict';
 
@@ -29,10 +29,10 @@ require.uncache = function (moduleName) {
 describe('wiredep', function () {
   beforeEach(function () {
     wiredep = require('../wiredep');
-  })
+  });
   afterEach(function () {
     require.uncache('../wiredep');
-  })
+  });
   before(function() {
     fs.copySync('test/fixture', '.tmp');
     process.chdir('.tmp');

--- a/wiredep.js
+++ b/wiredep.js
@@ -82,7 +82,7 @@ function wiredep(opts) {
 }
 
 function mergeFileTypesWithDefaults(optsFileTypes) {
-  var fileTypes = $._.clone(fileTypesDefault, true);
+  var fileTypes = $._.cloneDeep(fileTypesDefault);
 
   $._(optsFileTypes).each(function (fileTypeConfig, fileType) {
     // fallback to the default type for all html-like extensions (php, twig, hbs, etc)


### PR DESCRIPTION
Lodash changed the signature for `clone`.  To do a deep copy, the `cloneDeep` method must be used.  When fileType defaults were overridden by options these were replacing the actual fileType defaults.  Noticeable when running with defaults overridden, then running again expecting defaults.