### PR TITLE
Fix TypeError when streaming empty file

### DIFF
--- a/wiredep.js
+++ b/wiredep.js
@@ -135,7 +135,7 @@ wiredep.stream = function (opts) {
 
       file.contents = new Buffer(wiredep(opts));
     } catch (err) {
-      this.emit('error', err);
+      this.emit('error', 'Error processing file ' + file.path + ': ' + err);
     }
 
     this.push(file);

--- a/wiredep.js
+++ b/wiredep.js
@@ -128,7 +128,7 @@ wiredep.stream = function (opts) {
 
     try {
       opts.stream = {
-        src: file.contents.toString(),
+        src: file.contents.toString() || " ", //< must be anything but an empty string or null
         path: file.path,
         fileType: $.path.extname(file.path).substr(1)
       };


### PR DESCRIPTION
When streaming an empty file, a TypeError is thrown as decribed in #219 

This PR fixes that and provides a more helpful error if something is wrong with the argument passed to `Buffer`
