### PR TITLE
read main from alternatives' main as well

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -47,6 +47,15 @@ function detectDependencies(config) {
   return config;
 }
 
+/**
+ * does the config object have the proper main we need
+ *
+ * @param config
+ * @returns {Boolean}
+ */
+function isValidConfig(config) {
+  return $._.isObject(config) && config.main && config.main.length > 0;
+}
 
 /**
  * Find the component's JSON configuration file.
@@ -62,15 +71,32 @@ function findComponentConfigFile(config, component) {
     return config.get('bower.json');
   }
 
-  ['bower.json', '.bower.json', 'component.json', 'package.json'].
-    forEach(function (configFile) {
-      configFile = $.path.join(config.get('bower-directory'), component, configFile);
-
-      if (!$._.isObject(componentConfigFile) && $.fs.existsSync(configFile)) {
-        componentConfigFile = JSON.parse($.fs.readFileSync(configFile));
+  var candidates = ['bower.json', '.bower.json', 'component.json', 'package.json'];
+  for (var i = 0, len = candidates.length; i < len; i++) {
+    if (isValidConfig(componentConfigFile)) {
+      break;
+    }
+    var configFile = $.path.join(config.get('bower-directory'), component, candidates[i]);
+    if ($.fs.existsSync(configFile) === false) {
+      continue;
+    } else {
+      var curConfigFile = JSON.parse($.fs.readFileSync(configFile));
+      if ($._.isObject(componentConfigFile) === false) {
+        componentConfigFile = curConfigFile;
+        //current configFile match what we need
+        if (isValidConfig(curConfigFile)) {
+          break;
+        }
+      } else {
+        if (!componentConfigFile.main || componentConfigFile.main.length === 0) {
+          if (curConfigFile.main && curConfigFile.main.length > 0) {
+            componentConfigFile.main = curConfigFile.main;
+            break;
+          }
+        }
       }
-    });
-
+    }
+  }
   return componentConfigFile;
 }
 

--- a/test/fixture/bower_components/fake-package-only-has-package-json/package.json
+++ b/test/fixture/bower_components/fake-package-only-has-package-json/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-package-only-has-package-json",
+  "version": "1.0.0",
+  "main": "fake.js"
+}

--- a/test/wiredep_test.js
+++ b/test/wiredep_test.js
@@ -1,5 +1,5 @@
 /*jshint latedef:false */
-/*global after, describe, it, before, beforeEach */
+/*global after, describe, it, before, beforeEach, afterEach*/
 
 'use strict';
 
@@ -29,10 +29,10 @@ require.uncache = function (moduleName) {
 describe('wiredep', function () {
   beforeEach(function () {
     wiredep = require('../wiredep');
-  })
+  });
   afterEach(function () {
     require.uncache('../wiredep');
-  })
+  });
   before(function() {
     fs.copySync('test/fixture', '.tmp');
     process.chdir('.tmp');
@@ -468,6 +468,20 @@ describe('wiredep', function () {
     });
 
     assert.equal(filePaths.read('actual'), filePaths.read('expected'));
+  });
+
+  it('should read main field from package.json when main is missing from bower.json .bower.json',function(){
+    var bowerObj = {
+      name: 'test',
+      dependencies: {
+        'fake-package-only-has-package-json': '*'
+      }
+    };
+    var obj = wiredep({
+      bowerJson: bowerObj
+    });
+    assert.isTrue(obj.packages['fake-package-only-has-package-json'].main.length > 0);
+    assert.isTrue(obj.packages['fake-package-only-has-package-json'].main[0].indexOf('fake.js') > -1);
   });
 
   it('should support inclusion of main files from some other dir with manually loaded bower.json', function () {


### PR DESCRIPTION
In case of a component only present a `package.json`, generated .bower.json will not read the main, in wiredep, we shall read the `package.json`'s main before using  `component.name+'.js'` fallback.